### PR TITLE
ユーザのactivate機能の追加

### DIFF
--- a/app/assets/javascripts/account_activations.coffee
+++ b/app/assets/javascripts/account_activations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,15 @@
+class AccountActivationsController < ApplicationController
+
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      log_in user
+      flash[:success] = "Account activated!"
+      redirect_to user
+    else
+      flash[:danger] = "Invalid activation link"
+      redirect_to root_url
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,8 +5,15 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
-      log_in user
-      redirect_back_or user
+      if user.activated?
+        log_in user
+        redirect_back_or user
+      else
+        message = "Account not activated. "
+        message += "Check your email for the activation link."
+        flash[:warning] = message
+        redirect_to root_url
+      end
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,11 +5,12 @@ class UsersController < ApplicationController
 
 
   def index
-    @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
   end
 
   def new
@@ -19,9 +20,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in @user
-      flash[:success] = "Welcome to the Sample App!"
-      redirect_to @user
+      @user.send_activation_email
+      flash[:info] = "Please check your email to activate your account."
+      redirect_to root_url
     else
       render 'new'
     end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: "noreply@example.com"
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < ApplicationMailer
+
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "Account activation"
+  end
+
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
-  before_save {self.email = email.downcase}
+  attr_accessor :remember_token, :activation_token
+  before_save :downcase_email
+  before_create :create_activation_digest
   validates :name, presence: true, length: {maximum: 50}
   validates :email, presence: true, length: {maximum: 255}
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
@@ -13,5 +15,34 @@ class User < ApplicationRecord
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
+  end
+
+  def User.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
+  end
+
+  def activate
+    update_columns(activated: true, activated_at: Time.zone.now)
+  end
+
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
+  private
+
+  def downcase_email
+    self.email.downcase!
+  end
+
+  def create_activation_digest
+    self.activation_token = User.new_token
+    self.activation_digest = User.digest(activation_token)
   end
 end

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -1,8 +1,3 @@
-!!!
 %html
-  %head
-    %meta{:content => "text/html; charset=utf-8", "http-equiv" => "Content-Type"}/
-    :css
-      /* Email styles need to be inline */
   %body
     = yield

--- a/app/views/user_mailer/account_activation.html.haml
+++ b/app/views/user_mailer/account_activation.html.haml
@@ -1,0 +1,9 @@
+%h1 Sample App
+
+%p Hi
+= @user.name
+
+%p
+Welcome to the Sample App! Click on the link below to activate your account:
+
+= link_to "Activate", edit_account_activation_url(@user.activation_token,email: @user.email)

--- a/app/views/user_mailer/account_activation.text.haml
+++ b/app/views/user_mailer/account_activation.text.haml
@@ -1,0 +1,6 @@
+Hi
+= @user.name
+
+Welcome to the Sample App! Click on the link below to activate your account:
+
+= edit_account_activation_url(@user.activation_token, email: @user.email)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,10 @@ Rails.application.configure do
   # for session store.
   config.session_store_servers = 'redis://localhost:6379/0/session'
 
+
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :test
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = {host: host, protocol: 'http'}
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,4 +95,19 @@ Rails.application.configure do
 
   # for session store.
   config.session_store_servers = ENV["REDISCLOUD_URL"]
+
+  # for mailer
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'afternoon-badlands-51970.herokuapp.com'
+  config.action_mailer.default_url_options = {host: host}
+  ActionMailer::Base.smtp_settings = {
+      :address => 'smtp.sendgrid.net',
+      :port => '587',
+      :authentication => :plain,
+      :user_name => ENV['SENDGRID_USERNAME'],
+      :password => ENV['SENDGRID_PASSWORD'],
+      :domain => 'heroku.com',
+      :enable_starttls_auto => true
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,6 @@ Rails.application.configure do
 
   # for session store.
   config.session_store_servers = 'redis://localhost:6379/0/session'
+
+  config.action_mailer.default_url_options = {host: 'example.com'}
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
   resources :users
+  resources :account_activations, only: [:edit]
 end

--- a/db/migrate/20180222052427_add_activation_to_users.rb
+++ b/db/migrate/20180222052427_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222003705) do
+ActiveRecord::Schema.define(version: 20180222052427) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -19,6 +19,9 @@ ActiveRecord::Schema.define(version: 20180222003705) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.boolean "admin"
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,9 @@ User.create!(name: "Example User",
              email: "example@test.org",
              password: "foobar",
              password_confirmation: "foobar",
-             admin: true)
+             admin: true,
+             activated: true,
+             activated_at: Time.zone.now)
 
 99.times do |n|
   name = Faker::Name.name
@@ -11,5 +13,7 @@ User.create!(name: "Example User",
   User.create!(name: name,
                email: email,
                password: password,
-               password_confirmation: password)
+               password_confirmation: password,
+               activated: true,
+               activated_at: Time.zone.now)
 end

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AccountActivationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,25 +3,35 @@ michael:
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
   admin: true
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 archer:
   name: Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 lana:
   name: Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 malory:
   name: Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 <% 30.times do |n| %>
 user_<%= n %>:
   name:  <%= "User #{n}" %>
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 <% end %>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
 
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
+
   test "invalid signup information" do
     get signup_path
     assert_no_difference 'User.count' do
@@ -13,7 +17,8 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_template 'users/new'
   end
 
-  test "valid signup information" do
+  test "valid signup information with account activation" do
+
     get signup_path
     assert_difference 'User.count', 1 do
       post users_path, params: {user: {name: "Example User",
@@ -21,6 +26,21 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                                        password: "password",
                                        password_confirmation: "password"}}
     end
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    user = assigns(:user)
+    assert_not user.activated?
+    # activate前にログイン
+    log_in_as(user)
+    assert_not is_logged_in?
+    # 有効化tokenが間違い
+    get edit_account_activation_path("invalid token", email: user.email)
+    assert_not is_logged_in?
+    # メールアドレスが間違い
+    get edit_account_activation_path(user.activation_token, email: 'wrong')
+    assert_not is_logged_in?
+    # tokenが正しい
+    get edit_account_activation_path(user.activation_token, email: user.email)
+    assert user.reload.activated?
     follow_redirect!
     assert_template 'users/show'
     assert is_logged_in?

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,16 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  test "account_activation" do
+    user = users(:michael)
+    user.activation_token = User.new_token
+    mail = UserMailer.account_activation(user)
+    assert_equal "Account activation", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.name, mail.body.encoded
+    assert_match user.activation_token, mail.body.encoded
+    assert_match CGI.escape(user.email), mail.body.encoded
+  end
+
+end


### PR DESCRIPTION
#概要
掲題の通り
- mailを使用してのactivate機能を追加
- それに伴うテストの追加

*heroku側で私のアカウントが誤ってブロックされているようでsendgridアドオンが現在本番環境で使えない。ただいまherokuサポートに解除依頼中・・・・
対象チケット
https://help.heroku.com/tickets/557122

*アカウント復旧しました